### PR TITLE
Fix constraints for transformers package, fixes #8

### DIFF
--- a/mmorph.cabal
+++ b/mmorph.cabal
@@ -20,6 +20,6 @@ Library
     Hs-Source-Dirs: src
     Build-Depends:
         base         >= 4       && < 5  ,
-        transformers >= 0.2.0.0 && < 0.4
+        transformers >= 0.3.0.0 && < 0.4
     Exposed-Modules: Control.Monad.Morph, Control.Monad.Trans.Compose
     GHC-Options: -O2


### PR DESCRIPTION
The constraint on transformers was too lax, including version 0.2.0.0. But since mmorph depends on Control.Applicative.Backwards which was introduced in version 0.3.0.0 it's not OK to compile againts 0.2.0.0
