### PR TITLE
Allow transformers-0.6 and mtl-2.3

### DIFF
--- a/mmorph.cabal
+++ b/mmorph.cabal
@@ -21,8 +21,8 @@ Library
     Hs-Source-Dirs: src
     Build-Depends:
         base                >= 4.5     && < 5  ,
-        mtl                 >= 2.1     && < 2.3,
-        transformers        >= 0.2.0.0 && < 0.6,
+        mtl                 >= 2.1     && < 2.4,
+        transformers        >= 0.2.0.0 && < 0.7,
         transformers-compat >= 0.3     && < 0.8
     if impl(ghc < 8.0)
         Build-Depends:


### PR DESCRIPTION
https://hackage.haskell.org/package/transformers-0.6.0.0/changelog
https://hackage.haskell.org/package/mtl-2.3/changelog

---

Blocked on:

* [x] https://github.com/haskell/mtl/issues/88 (needs [release](https://github.com/haskell/mtl/issues/86))