### PR TITLE
Update dependencies & CI

### DIFF
--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -11,20 +11,26 @@ jobs:
 
     runs-on: ubuntu-latest
 
+    strategy:
+      matrix:
+        ghc: ['8.10', '9.0', '9.2', '9.4', '9.6', '9.8', '9.10', '9.12', '9.14']
+      fail-fast: false
+
     steps:
-    - uses: actions/checkout@v2
-    - uses: haskell/actions/setup@v1.2
+    - uses: actions/checkout@v6
+    - uses: haskell-actions/setup@v2
+      id: setup-haskell
+      with:
+        ghc-version: ${{ matrix.ghc }}
     - name: Cache
-      uses: actions/cache@v1
+      uses: actions/cache@v5
       env:
         cache-name: cache-cabal
       with:
-        path: ~/.cabal
-        key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/*.cabal') }}-${{ hashFiles('**/cabal.project') }}
-        restore-keys: |
-          ${{ runner.os }}-build-${{ env.cache-name }}-
-          ${{ runner.os }}-build-
-          ${{ runner.os }}-
+        path: |
+          ${{ steps.setup-haskell.outputs.cabal-store }}
+          dist-newstyle
+        key: ${{ runner.os }}-${{ matrix.ghc }}
 
     - name: Install dependencies
       run: |

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+dist-mcabal
+dist-newstyle
+.stack-work

--- a/mmorph.cabal
+++ b/mmorph.cabal
@@ -12,7 +12,7 @@ Synopsis: Monad morphisms
 Description: This library provides monad morphism utilities, most commonly used
     for manipulating monad transformer stacks.
 Category: Control
-Extra-Source-Files: CHANGELOG.md
+Extra-Doc-Files: CHANGELOG.md
 Source-Repository head
     Type: git
     Location: https://github.com/Gabriella439/Haskell-MMorph-Library
@@ -20,13 +20,10 @@ Source-Repository head
 Library
     Hs-Source-Dirs: src
     Build-Depends:
-        base                >= 4.5     && < 5  ,
-        mtl                 >= 2.1     && < 2.4,
-        transformers        >= 0.2.0.0 && < 0.7,
-        transformers-compat >= 0.6.1   && < 0.8
-    if impl(ghc < 8.0)
-        Build-Depends:
-            fail == 4.9.*
+        base                >= 4.14  && < 5  ,
+        mtl                 >= 2.1   && < 2.4,
+        transformers        >= 0.5   && < 0.7,
+        transformers-compat >= 0.6.1 && < 0.8
     Exposed-Modules: Control.Monad.Morph, Control.Monad.Trans.Compose
     GHC-Options: -O2
     Default-Language: Haskell2010

--- a/mmorph.cabal
+++ b/mmorph.cabal
@@ -13,6 +13,8 @@ Description: This library provides monad morphism utilities, most commonly used
     for manipulating monad transformer stacks.
 Category: Control
 Extra-Doc-Files: CHANGELOG.md
+Tested-With: GHC == 8.10.7, GHC == 9.0.2, GHC == 9.2.8, GHC == 9.4.8, GHC == 9.6.7, GHC == 9.8.4, GHC == 9.10.3, GHC == 9.12.2, GHC == 9.14.1
+
 Source-Repository head
     Type: git
     Location: https://github.com/Gabriella439/Haskell-MMorph-Library

--- a/src/Control/Monad/Morph.hs
+++ b/src/Control/Monad/Morph.hs
@@ -1,9 +1,6 @@
-{-# LANGUAGE CPP        #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE Safe       #-}
-#if __GLASGOW_HASKELL__ >= 706
 {-# LANGUAGE PolyKinds  #-}
-#endif
 
 {-| A monad morphism is a natural transformation:
 

--- a/src/Control/Monad/Trans/Compose.hs
+++ b/src/Control/Monad/Trans/Compose.hs
@@ -6,12 +6,8 @@
 {-# LANGUAGE StandaloneKindSignatures   #-}
 {-# LANGUAGE UndecidableInstances       #-}
 {-# LANGUAGE DeriveTraversable          #-}
-{-# LANGUAGE CPP                        #-}
 {-# LANGUAGE Trustworthy                #-}
-
-#if __GLASGOW_HASKELL__ >= 806
-{-# LANGUAGE QuantifiedConstraints #-}
-#endif
+{-# LANGUAGE QuantifiedConstraints      #-}
 
 {-| Composition of monad transformers. A higher-order version of
     "Data.Functor.Compose".
@@ -73,11 +69,9 @@ instance (MFunctor f, MonadTrans f, MonadTrans g) => MonadTrans (ComposeT f g)
   where
     lift = ComposeT . hoist lift . lift
 
-#if defined(__MHS__) || __GLASGOW_HASKELL__ >= 806
 instance (MFunctor f, MFunctor g, forall m. Monad m => Monad (g m))
     => MFunctor (ComposeT f g) where
     hoist f (ComposeT m) = ComposeT (hoist (hoist f) m)
-#endif
 
 -- | Transform the computation inside a 'ComposeT'.
 mapComposeT :: (f (g m) a -> p (q n) b) -> ComposeT f g m a -> ComposeT p q n b


### PR DESCRIPTION
`StandaloneKindSignatures` (which was introduced in #73) requires GHC >= 8.10, or equivalently, base >= 4.14. GHC 8.10 was released almost 6 years ago, so I think it's fine to drop support for older versions. This also allows us to get rid of CPP. If you want to keep compatibility with older versions, I can guard the standalone kind signature behind an `#ifdef __MHS__`.

I also updated the CI to test all supported GHC versions and added a `.gitignore`.