### PR TITLE
Add MicroHs CI

### DIFF
--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -2,9 +2,9 @@ name: Haskell CI
 
 on:
   push:
-    branches: [ master ]
+    branches: [ main ]
   pull_request:
-    branches: [ master ]
+    branches: [ main ]
 
 jobs:
   build:

--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -38,3 +38,28 @@ jobs:
         cabal build --only-dependencies --enable-tests --enable-benchmarks
     - name: Build
       run: cabal build --enable-tests --enable-benchmarks all
+
+  build-mhs:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v6
+    - name: Checkout MicroHs repository
+      uses: actions/checkout@v6
+      with:
+        repository: augustss/MicroHs
+        ref: 166fbe20c8b8469852a0a99816cee9ac487e0780
+        path: mhs
+    - name: Install MicroHs
+      run: |
+        cd mhs
+        make minstall
+        echo "$HOME/.mcabal/bin" >> $GITHUB_PATH
+    - name: Install dependencies
+      run: |
+        mcabal install ghc-compat
+        mcabal install transformers
+        mcabal install --git=https://github.com/ekmett/transformers-compat.git transformers-compat
+        mcabal install mtl
+    - name: Install mmorph
+      run: mcabal install


### PR DESCRIPTION
Build MicroHs from the currently latest commit and install `mmorph` and its dependencies.

I noticed that the CI didn't run, due to having the wrong branch name, so I fixed that.